### PR TITLE
fix(contract-methods): add missing optional value and contractAddress parameters to Execute method

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -140,9 +140,11 @@ execution, err := c.ContractMethods().Execute(
         "amount": "1000000000000000000", // 1 ETH in wei
         "to":     "0x456...",
     },
-    nil,
-    nil,
-    nil,
+    nil, // walletId
+    nil, // memo
+    nil, // authorizationList
+    nil, // value
+    nil, // contractAddress
 )
 
 // Get method details

--- a/clients/go/contractMethods.go
+++ b/clients/go/contractMethods.go
@@ -21,6 +21,8 @@ func (t *ContractMethods) Execute(
 	params map[string]interface{},
 	walletId, memo *string,
 	authorizationList []swagger.Erc7702Authorization,
+	value *string,
+	contractAddress *string,
 ) (*swagger.Transaction, error) {
 	body := swagger.ContractMethodIdExecuteBody{}
 	if params != nil {
@@ -42,6 +44,12 @@ func (t *ContractMethods) Execute(
 	}
 	if authorizationList != nil {
 		body.AuthorizationList = authorizationList
+	}
+	if value != nil {
+		body.Value = *value
+	}
+	if contractAddress != nil {
+		body.ContractAddress = *contractAddress
 	}
 	resp, _, err := t.api.MethodsContractMethodIdExecutePost(ctx, body, contractMethodId)
 	if err != nil {


### PR DESCRIPTION
## 📌 Summary
This PR fixes an issue in the `ContractMethods.Execute` method by adding the missing optional parameters:
- `value`
- `contractAddress`

These parameters are required to ensure proper execution of contracts in cases where a value transfer or a specific contract address is involved.

## ✅ Changes
- Added `value` as an optional parameter to `Execute` method.
- Added `contractAddress` as an optional parameter to `Execute` method.
- Adjusted documentation and usage examples (if any).